### PR TITLE
Fixes Dispose method on IntersectionObserver to reference this.element

### DIFF
--- a/demo/vpaid/vpaid-client.js
+++ b/demo/vpaid/vpaid-client.js
@@ -1619,8 +1619,8 @@ var IntersectionObserver = function (_BaseTechnique) {
     key: 'dispose',
     value: function dispose() {
       if (this.observer) {
-        this.observer.unobserve(element);
-        this.observer.disconnect(element);
+        this.observer.unobserve(this.element);
+        this.observer.disconnect(this.element);
       }
     }
 

--- a/dist/openvv.js
+++ b/dist/openvv.js
@@ -1563,8 +1563,8 @@ var IntersectionObserver = function (_BaseTechnique) {
     key: 'dispose',
     value: function dispose() {
       if (this.observer) {
-        this.observer.unobserve(element);
-        this.observer.disconnect(element);
+        this.observer.unobserve(this.element);
+        this.observer.disconnect(this.element);
       }
     }
 

--- a/src/Measurement/MeasurementTechniques/IntersectionObserver.js
+++ b/src/Measurement/MeasurementTechniques/IntersectionObserver.js
@@ -46,8 +46,8 @@ export default class IntersectionObserver extends BaseTechnique {
    */
   dispose() {
     if(this.observer) {
-      this.observer.unobserve(element);
-      this.observer.disconnect(element);
+      this.observer.unobserve(this.element);
+      this.observer.disconnect(this.element);
     }
   }
 


### PR DESCRIPTION
Prevents runtime errors during a dispose call of `Uncaught ReferenceError: element is not defined`

Resolved #23 